### PR TITLE
chore(core): print file loading errors to stderr instead of stdout

### DIFF
--- a/scaleway-core/scaleway_core/api.py
+++ b/scaleway-core/scaleway_core/api.py
@@ -108,7 +108,7 @@ class API:
             client.validate()
 
         self.client = client
-        self._log = logging.getLogger(__name__)
+        self._log = logging.getLogger("scaleway")
 
     def _request(
         self,

--- a/scaleway-core/scaleway_core/profile/profile.py
+++ b/scaleway-core/scaleway_core/profile/profile.py
@@ -5,6 +5,7 @@ import logging
 import os
 from dataclasses import dataclass
 from typing import Optional, Type, TypeVar
+import sys
 
 import yaml
 from scaleway_core import __version__
@@ -197,7 +198,7 @@ class Profile(ProfileDefaults, ProfileConfig):
             config_profile = cls.from_config_file(filepath, profile_name)
             has_config_profile = True
         except Exception as e:
-            print(e)
+            print(e, file=sys.stderr)
 
         env_profile = cls.from_env(force_none=has_config_profile)
         if has_config_profile:

--- a/scaleway-core/scaleway_core/profile/profile.py
+++ b/scaleway-core/scaleway_core/profile/profile.py
@@ -198,7 +198,9 @@ class Profile(ProfileDefaults, ProfileConfig):
             config_profile = cls.from_config_file(filepath, profile_name)
             has_config_profile = True
         except Exception as e:
-            print(e, file=sys.stderr)
+            logging.getLogger("scaleway").warning(
+                f"Could not load profile from config file: {e}"
+            )
 
         env_profile = cls.from_env(force_none=has_config_profile)
         if has_config_profile:


### PR DESCRIPTION
:wave: Hey team!

Just a tiny change to print file loading errors to stderr instead of stdout. This error sometimes appears in CIs where the config file is not found and can sometimes be a red herring when using `Client.from_config_file_and_env()` method where the envs are declared but the config file does not exist. This small change makes it easier to split this log from other logs.

It looks like it's the only use of print in the codebase.

Have a great day!