### PR TITLE
feat(core): allow the use of a requests session

### DIFF
--- a/scaleway-core/scaleway_core/api.py
+++ b/scaleway-core/scaleway_core/api.py
@@ -103,7 +103,13 @@ class ValidationError(ScalewayException):
 
 
 class API:
-    def __init__(self, client: Client, *, bypass_validation: bool = False, session: Optional[Session] = None):
+    def __init__(
+        self,
+        client: Client,
+        *,
+        bypass_validation: bool = False,
+        session: Optional[Session] = None,
+    ):
         if not bypass_validation:
             client.validate()
 

--- a/scaleway-core/scaleway_core/api.py
+++ b/scaleway-core/scaleway_core/api.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import IO, Any, Dict, Iterable, Mapping, Optional, Tuple, Union
 
 import requests
-from requests import Response, Session
+from requests import Response
 
 from .client import Client
 
@@ -103,19 +103,12 @@ class ValidationError(ScalewayException):
 
 
 class API:
-    def __init__(
-        self,
-        client: Client,
-        *,
-        bypass_validation: bool = False,
-        session: Optional[Session] = None,
-    ):
+    def __init__(self, client: Client, *, bypass_validation: bool = False):
         if not bypass_validation:
             client.validate()
 
         self.client = client
         self._log = logging.getLogger("scaleway")
-        self._session = session or requests.Session()
 
     def _request(
         self,
@@ -158,7 +151,7 @@ class API:
             body=raw_body,
         )
 
-        response = self._session.request(
+        response = requests.request(
             method=method,
             url=url,
             params=params,

--- a/scaleway-core/scaleway_core/api.py
+++ b/scaleway-core/scaleway_core/api.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import IO, Any, Dict, Iterable, Mapping, Optional, Tuple, Union
 
 import requests
-from requests import Response
+from requests import Response, Session
 
 from .client import Client
 
@@ -103,12 +103,13 @@ class ValidationError(ScalewayException):
 
 
 class API:
-    def __init__(self, client: Client, *, bypass_validation: bool = False):
+    def __init__(self, client: Client, *, bypass_validation: bool = False, session: Optional[Session] = None):
         if not bypass_validation:
             client.validate()
 
         self.client = client
         self._log = logging.getLogger("scaleway")
+        self._session = session or requests.Session()
 
     def _request(
         self,
@@ -151,7 +152,7 @@ class API:
             body=raw_body,
         )
 
-        response = requests.request(
+        response = self._session.request(
             method=method,
             url=url,
             params=params,

--- a/scaleway-core/scaleway_core/client.py
+++ b/scaleway-core/scaleway_core/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import logging
-from dataclasses import dataclass
+import requests
 from typing import Optional
 
 from scaleway_core.profile import Profile
@@ -18,6 +17,11 @@ from scaleway_core.validations.string_validation import (
 
 class Client(Profile):
     _request_count: int = 1
+
+    """
+    session is used to share a session between multiple API clients.
+    """
+    session: Optional[requests.Session] = None
 
     @staticmethod
     def from_profile(profile: Profile) -> Client:


### PR DESCRIPTION
Hey :waffle: !

I'm not sure if this is a common pain point, but it would be quite useful to be able to pass a `requests.session` to the API classes. One possible use case is to pass a [`Retry`](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry) parameter to retry in case of 500. This is quite nice as one instability can break a script, when most of the time we could just retry.

```
api = sdk.AccountV2API(client, session=requests.Session(retries=Retry(total=10)))
project = api.create_project(name="toto")
```

Since this PR introduces some weird changes in the API, you could also just create an empty session as an attribute so it could be modified by modifying the attribute.

```
api = sdk.AccountV2API(client)
api._session = requests.Session(retries=Retry())
```

Cheers!
Have a lovely day!