### PR TITLE
fix(domain): Added marshalling for set,add,delete,clear records

### DIFF
--- a/scaleway/scaleway/domain/v2beta1/marshalling.py
+++ b/scaleway/scaleway/domain/v2beta1/marshalling.py
@@ -3257,17 +3257,27 @@ def marshal_RecordChange(
     defaults: ProfileDefaults,
 ) -> Dict[str, Any]:
     output: Dict[str, Any] = {}
-    output.update(
-        resolve_one_of(
+    changeRecord = resolve_one_of(
             [
                 OneOfPossibility("add", request.add),
                 OneOfPossibility("set", request.set_),
                 OneOfPossibility("delete", request.delete),
                 OneOfPossibility("clear", request.clear),
             ]
-        ),
-    )
-
+        )
+    
+    match changeRecord:
+        case {"set": recordChangeSet}:
+            output.update({"set": marshal_RecordChangeSet(recordChangeSet[0], defaults)})
+        case {"add": recordChangeAdd}:
+            output.update({"add": marshal_RecordChangeAdd(recordChangeAdd[0], defaults)})
+        case {"delete": recordChangeDelete}:
+            output.update({"delete": marshal_RecordChangeDelete(recordChangeDelete[0], defaults)})
+        case {"clear": recordChangeClear}:
+            output.update({"clear": marshal_RecordChangeClear(recordChangeClear[0], defaults)})
+        case _:
+            raise TypeError("Invalid key in change record. Only 'set', 'add', 'delete' and 'clear' are supported")
+        
     return output
 
 

--- a/scaleway/tests/test_record_change_marshalling.py
+++ b/scaleway/tests/test_record_change_marshalling.py
@@ -1,0 +1,28 @@
+import unittest
+from scaleway.domain.v2beta1.marshalling import marshal_RecordChange
+from scaleway_core.profile.profile import ProfileDefaults
+from scaleway.domain.v2beta1.types import RecordChangeSet, RecordChange, Record, RecordType
+
+class TestRecordChangeMarshalling(unittest.TestCase):
+    def test_marshalRecord(self):
+        recordToUpdate: Record = Record(data="1.1.1.1", name="test", priority=1, ttl=3600, type_=RecordType.A, id="1536b046-23c8-4a67-9266-8828d7cd2785",
+                                        comment=None, geo_ip_config=None, http_service_config=None, view_config=None, weighted_config=None)
+        changes: RecordChange = RecordChange(
+            set_ = [
+                RecordChangeSet(records=[recordToUpdate], id=recordToUpdate.id, id_fields=None)
+            ],
+            delete = None,
+            clear = None,
+            add = None
+        )
+        defaults = ProfileDefaults()
+        actual = marshal_RecordChange(changes, defaults)
+
+        expected = {'set': {'id': '1536b046-23c8-4a67-9266-8828d7cd2785',
+                    'records': [{'data': '1.1.1.1',
+                    'id': '1536b046-23c8-4a67-9266-8828d7cd2785',
+                    'name': 'test',
+                    'priority': 1,
+                    'ttl': 3600,
+                    'type': 'a'}]}}
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
The RecordChange subtypes have not been marshalled correctly to the expected format and could not be dumped as json. This fix ensures that the subtypes are now correctly converted